### PR TITLE
more efficient scaling of inputs

### DIFF
--- a/VAE-GAN-multi-gpu-celebA.ipynb
+++ b/VAE-GAN-multi-gpu-celebA.ipynb
@@ -176,8 +176,8 @@
    "outputs": [],
    "source": [
     "# Normalize the dataset between 0 and 1\n",
-    "# inplace is more memory efficient\n",
-    "faces.astype(np.float32)\n",
+    "# convert to float32 and scale inplace is more memory efficient\n",
+    "faces = faces.astype(np.float32)\n",
     "faces /= 255."
    ]
   },

--- a/VAE-GAN-multi-gpu-celebA.ipynb
+++ b/VAE-GAN-multi-gpu-celebA.ipynb
@@ -176,7 +176,9 @@
    "outputs": [],
    "source": [
     "# Normalize the dataset between 0 and 1\n",
-    "faces = (faces/255.)"
+    "# inplace is more memory efficient\n",
+    "faces.astype(np.float32)\n",
+    "faces /= 255."
    ]
   },
   {
@@ -1609,6 +1611,18 @@
    "display_name": "Python 2",
    "language": "python",
    "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
using explicit conversion to np.float32 and inplace scaling saved me ~8GB of RAM.
